### PR TITLE
feat: dsn in the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The payload you send must be in the following format:
 
 ```javascript
 {
+    "dsn": "your Sentry DSN here",
     "release": {
         "name": "myAppsReleaseName",
         "version": "1.0.0"
@@ -67,8 +68,9 @@ The payload you send must be in the following format:
 }
 ```
 
-Required fields: release, environment, message, level.
+Required attributes: release, environment, message, level.
 
+- The dsn attribute is optional. If it's not informed, the payload is still valid. If it is informed, it will only be used if no SENTRY_DSN value is configured as enviornment variable in the lambda. The implementation was done this way so that the deployed lambda is used for only 1 project at a time and runtime costs are better controlled.
 - Inside release should be your app's name and version, so Sentry issues can be associated with an app release.
 - Inside environment, you can send production, staging or development, according to the environment where the app is running.
 - Level (Sentry Severity) must be one of these: fatal, error, warning, log, info, debug, critical

--- a/lambda/Log2Sentry.ts
+++ b/lambda/Log2Sentry.ts
@@ -2,7 +2,7 @@ import { APIGatewayEvent, APIGatewayEventRequestContext } from "aws-lambda";
 import Util from "./helpers/util";
 import { HttpCode } from "./dto/http-codes";
 import Logger from "./helpers/logger";
-import { Log2SentryRequest } from "./interfaces";
+import { Log2SentryRequest, SentryInit } from "./interfaces";
 
 class Log2Sentry {
 
@@ -42,13 +42,19 @@ class Log2Sentry {
 
     private initSentry(payload: Log2SentryRequest): void {
         this.validateInit(payload);
-        if (payload.release && payload.release.name && payload.release.version) {
-            if (payload.environment) {
-                Logger.init(payload.release.name, payload.release.version, payload.environment);
-            } else {
-                Logger.init(payload.release.name, payload.release.version);
-            }
+        const config: SentryInit = {
+            name: payload.release.name,
+            version: payload.release.version
+        };
+
+        if (payload.environment) {
+            config.environment = payload.environment;
         }
+        if (payload.dsn) {
+            config.dsn = payload.dsn;
+        }
+
+        Logger.init(config);
     }
 
     private validateInit(payload: Log2SentryRequest): void {

--- a/lambda/helpers/logger.ts
+++ b/lambda/helpers/logger.ts
@@ -1,18 +1,19 @@
 import * as sentry from "@sentry/node";
 import pino from "pino";
+import { SentryInit } from "../interfaces";
 const log = pino();
 import Util from "./util";
 
 class Logger {
-    init(name: string, version: string, environment?: string): void {
-        const config = {
-            dsn: process.env.SENTRY_DSN,
-            release: `${name}@${version}`
+    init(config: SentryInit): void {
+        const options: sentry.NodeOptions = {
+            dsn: process.env.SENTRY_DSN || config.dsn,
+            release: `${config.name}@${config.version}`
         };
-        if (environment) {
-            config["environment"] = environment;
+        if (config.environment) {
+            options["environment"] = config.environment;
         }
-        sentry.init(config);
+        sentry.init(options);
         this.clearScope();
     }
 

--- a/lambda/interfaces.ts
+++ b/lambda/interfaces.ts
@@ -25,6 +25,7 @@ export interface Breadcrumb {
 }
 
 export interface Log2SentryRequest {
+    dsn?: string;
     release: Release;
     environment: "production | staging | development";
     message: string;
@@ -32,4 +33,11 @@ export interface Log2SentryRequest {
     user: User;
     tags: Tag[];
     breadcrumbs: Breadcrumb[];
+}
+
+export interface SentryInit {
+    name: string;
+    version: string;
+    environment?: string;
+    dsn?: string;
 }


### PR DESCRIPTION
The dsn attribute is optional. If it's not informed, the payload is still valid. If it is informed, it will only be used if no SENTRY_DSN value is configured as enviornment variable in the lambda. The implementation was done this way so that the deployed lambda is used for only 1 project at a time and runtime costs are better controlled.